### PR TITLE
added additional option for static files outside the basePath

### DIFF
--- a/paperpress.js
+++ b/paperpress.js
@@ -21,6 +21,7 @@ var Paperpress = function (config) {
 	this.basePath = config.basePath;
 	this.pagesPath = config.pagesPath;
 	this.articlesPerPage = config.articlesPerPage || 5;
+	this.staticPath = config.staticPath || this.basePath;
 	this.articles = [];
 	this.pages = [];
 
@@ -150,7 +151,7 @@ Paperpress.prototype.attach = function(server) {
 		}
 
 		var renderedHtml = paperpress.multipleTpl({
-			static  : paperpress.basePath,
+			static  : paperpress.staticPath,
 			baseUrl : paperpress.basePath,
 			articles : articles
 		});
@@ -170,7 +171,7 @@ Paperpress.prototype.attach = function(server) {
 		}
 
 		var renderedHtml = paperpress.singleTpl({
-			static  : paperpress.basePath,
+			static  : paperpress.staticPath,
 			baseUrl : paperpress.basePath,
 			article : article
 		});
@@ -195,7 +196,7 @@ Paperpress.prototype.attach = function(server) {
 	pages.forEach(function (page) {
 		server.get(paperpress.pagesPath + '/' + page.path, function(req, res){
 			var renderedHtml = paperpress.pageTpl({
-				static  : paperpress.basePath,
+				static  : paperpress.staticPath,
 				baseUrl : paperpress.pagesPath,
 				page    : page
 			});


### PR DESCRIPTION
Hola estoy probando implementar paperpress en mi proyecto, estaba intentando tener la siguiente estructura de archivos:
![screen shot 2014-05-26 at 5 36 49 pm](https://cloud.githubusercontent.com/assets/225445/3086135/50a6a4d2-e526-11e3-8c2b-50f7ec1dc965.png)

Pero me di cuenta que paperpress me obliga a tener los assets dentro de el basePath, y desde qué estoy adaptándolo con algo que ya maneja assets, creo que estaría bueno poder especificar en donde están estos archivos, en este caso yo ya le digo a express cual es mi carpeta estática, con:
```server.use( express.static(path.join(__dirname, '/public')) ); ```
De tal suerte qué, si yo digo que mi staticPath es la raíz ( / ) podrá encontrar fácilmente los assets en mi carpeta public.
