### PR TITLE
Add npmignore file.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.gitignore
+.eslintrc
+.travis.yml
+gulpfile.js
+examples
+test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paperpress
+# [Paperpress](https://github.com/Siedrix/paperpress)
 
 [![Build Status](https://travis-ci.org/Siedrix/paperpress.svg?branch=master)](https://travis-ci.org/Siedrix/paperpress)
 [![Coverage Status](https://coveralls.io/repos/github/Siedrix/paperpress/badge.svg?branch=master)](https://coveralls.io/github/Siedrix/paperpress?branch=master)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Create a Paperpress instance
 ```js
 var Paperpress = require('paperpress')
 var paperpress = new Paperpress({
-  baseDirectory: 'test/static'
+  baseDirectory: 'static'
 })
 paperpress.load()
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 > Paperpress is a static pages generator for Nodejs.
 
+[![NPM](https://nodei.co/npm/paperpress.png?downloads=true&stars=true)](https://nodei.co/npm/paperpress/)
+
 This library will allow you to have a blog or static pages in markdown on top of any application with express, koa or any other Node.js http server.
 
 For feature request, contact @[Siedrix](http://siedrix.com) on [twitter](https://twitter.com/Siedrix) or [github](https://github.com/Siedrix/paperpress/issues/new).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "paperpress",
   "version": "0.9.8",
   "main": "./paperpress",
+  "description": "A static pages generator for Node.js.",
   "scripts": {
     "test": "./node_modules/mocha/bin/_mocha -R spec && npm run lint",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R nyan",


### PR DESCRIPTION
The `devDependencies` section of npm's package.json documentation says to list your test dependencies there so that users of your package don't have to pull down extra dependencies.

A `.npmignore` file works in similar way so users don't have to download the `test` and the `examples` folders when they install paperpress from `npm install paperpress`, only download the library.