### PR TITLE
Front Matter support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "feed": "~0.3.0",
+    "front-matter": "^2.0.7",
     "highlight.js": "^9.3.0",
     "remarkable": "^1.6.2"
   },

--- a/paperpress.js
+++ b/paperpress.js
@@ -125,24 +125,31 @@ Paperpress.prototype._fileToItem = function (file) {
 
 	if (frontMatter.test(fileContent)) {
 		var contentData = frontMatter(fileContent)
-		var attr = contentData.attributes
+		var dataAttributes = contentData.attributes
 
-		item = {
-			title: attr.title,
-			slug: attr.slug,
-			path: attr.path,
-			content: contentData.body
+		// Iterate through attributes and merge into the default item
+		for (var k in dataAttributes) {
+			if (dataAttributes.hasOwnProperty(k)) {
+				item[k] = dataAttributes[k]
+			}
 		}
-		if (attr.date) {
-			item['date'] = new Date(attr.date)
+
+		// Assign parsed content
+		item.content = contentData.body
+
+		// If date exists then parse it
+		if (dataAttributes.date) {
+			item.date = new Date(dataAttributes.date)
 		}
 	}
 
+	// If path was not assigned, then use helper method
 	item.path = item.path ? item.path : this.pathBuilder(item, file.collectionName)
 	this.paths.push(item.path)
 
+	// Do not render as markdown if file is .html
 	if (fileType !== '.html') {
-		item.content = marked.render(item.content)
+		item.content = this._marked.render(item.content)
 	}
 
 	return item

--- a/paperpress.js
+++ b/paperpress.js
@@ -127,12 +127,13 @@ Paperpress.prototype._fileToItem = function (file) {
 		var contentData = frontMatter(fileContent)
 		var dataAttributes = contentData.attributes
 
-		// Iterate through attributes and merge into the default item
-		for (var k in dataAttributes) {
-			if (dataAttributes.hasOwnProperty(k)) {
+		Object.keys(dataAttributes)
+			.filter(function (k) { // prevents attribute leaking
+				return dataAttributes.hasOwnProperty(k)
+			})
+			.forEach(function (k) { // merges into item object
 				item[k] = dataAttributes[k]
-			}
-		}
+			})
 
 		// Assign parsed content
 		item.content = contentData.body

--- a/test/static/articles/frontmatter-attr-test.md
+++ b/test/static/articles/frontmatter-attr-test.md
@@ -1,0 +1,5 @@
+---
+title: Is there life on Mars?
+date: 2016-05-03
+slug: life-on-mars
+---

--- a/test/static/articles/frontmatter-missing-attr-test.md
+++ b/test/static/articles/frontmatter-missing-attr-test.md
@@ -1,0 +1,3 @@
+---
+path: ashes-to-ashes
+---

--- a/test/test.js
+++ b/test/test.js
@@ -98,7 +98,7 @@ describe('Paperpress', function () {
 			paperpress._loadCollection('articles')
 
 			assert.equal( _.isArray( paperpress.items ), true )
-			assert.equal( paperpress.items.length, 7 )
+			assert.equal( paperpress.items.length, 9 )
 		})
 
 		it('paperpress should get collection into items array with out repetition', function () {
@@ -107,7 +107,7 @@ describe('Paperpress', function () {
 			paperpress._loadCollection('articles')
 
 			assert.equal( _.isArray( paperpress.items ), true )
-			assert.equal( paperpress.items.length, 7 )
+			assert.equal( paperpress.items.length, 9 )
 		})
 
 		it('paperpress should get collection into items array running the hooks', function () {
@@ -121,7 +121,7 @@ describe('Paperpress', function () {
 			paperpress._loadCollection('articles')
 
 			assert.equal( _.isArray( paperpress.items ), true )
-			assert.equal( paperpress.items.length, 7 )
+			assert.equal( paperpress.items.length, 9 )
 			assert.equal( paperpress.items[0].hookRunning, true )
 			assert.equal( paperpress.items[0].secondHookRunning, true )
 		})
@@ -133,7 +133,7 @@ describe('Paperpress', function () {
 			paperpress.load()
 
 			assert.equal( _.isArray( paperpress.items ), true )
-			assert.equal( paperpress.items.length, 11 )
+			assert.equal( paperpress.items.length, 13 )
 		})
 	})
 
@@ -144,7 +144,7 @@ describe('Paperpress', function () {
 
 			var articles = paperpress.getCollection('articles')
 			assert.equal( _.isArray( articles ), true )
-			assert.equal( articles.length, 7 )
+			assert.equal( articles.length, 9 )
 
 			var pages = paperpress.getCollection('pages')
 			assert.equal( _.isArray( pages ), true )
@@ -163,7 +163,7 @@ describe('Paperpress', function () {
 
 			var articlesAndSnippets = paperpress.getCollections(['articles', 'snippets'])
 			assert.equal( _.isArray( articlesAndSnippets ), true )
-			assert.equal( articlesAndSnippets.length, 9 )
+			assert.equal( articlesAndSnippets.length, 11 )
 
 			var pagesAndSnippets = paperpress.getCollections(['pages', 'snippets'])
 			assert.equal( _.isArray( pagesAndSnippets ), true )
@@ -314,7 +314,7 @@ describe('Paperpress reload', function () {
 
 		var articles = paperpress.getCollection('articles')
 		assert.equal( _.isArray( articles ), true )
-		assert.equal( articles.length, 7 )
+		assert.equal( articles.length, 9 )
 
 		var pages = paperpress.getCollection('pages')
 		assert.equal( _.isArray( pages ), true )


### PR DESCRIPTION
#### What does this PR do?
-  Uses `front-matter` npm dependency.
- Single file option does not support item attributes, this change extends the functionality to use Front Matter to retrieve the attributes if available on single MD files. 
- Supports HTML files too since it avoids Remarkable rendering if the extension matches.
- Supports the following cases:

**file.md**
````
# Lorem Ipsum
Dolor Sit Amet
```
**header.md**
```
---
title: "header"
slug: "header"
path: /blog/snippets/header
---
## This is the header
```
**another.html**
```
<div id="title"><h1>Ground Control to Major Tom</h1></div>
```

This will return a valid object populated with the available options (title, slug, path and content) either choosing between Front Matter, clean MD or HTML file.

#### Where should the reviewer start?
- Check `front-matter` dependency in `package.json`
- Open `paperpress.js` and review the `Paperpress.prototype._fileToItem` private method.

#### Any background context you want to provide?
- This was discussed during a review at the JavascriptMX Slack channel.
- Since this is detecting if a file has or do not has Front Matter headers, this works _"automagically"_, since we don't need an extra option when initialised. Although, we could add an additional parameter to trigger it.